### PR TITLE
Ignore anything added to 'Instrument Drivers'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,9 +25,8 @@ sccprj/
 Palladium DAQ - Settings/
 
 # Drivers
-Palladium DAQ/Instrument Drivers/Paragraf MIST/
-Palladium DAQ/Instrument Drivers/Zurich Instruments/
-Palladium DAQ/Instrument Drivers/Quantum Design/
+Palladium DAQ/Instrument Drivers/
+!Palladium DAQ/Instrument Drivers/.gitkeep
 
 # Presets other than the default example and the PPMS example
 Palladium DAQ/+PalladiumPresets/ADR.m


### PR DESCRIPTION
Ignores anything added to 'Instrument Drivers' except .gitkeep. Previously, `.gitignore` only ignored certain instrument drivers. This change makes it so new drivers can't accidentally be committed and pushed to the repository.