### PR TITLE
Made all filepath-related code be Mac and Linux compatiable

### DIFF
--- a/Palladium DAQ/+Palladium/+Sequence/SequenceEditorController.m
+++ b/Palladium DAQ/+Palladium/+Sequence/SequenceEditorController.m
@@ -52,8 +52,8 @@ classdef SequenceEditorController < handle
             %from the desired filename
 
             %Construct the needed paths
-            viewDir = applicationDir + "\\+Palladium\\+Sequence\\+Views\\";
-            fullViewCodeFilePath = viewDir + viewFileName;
+            viewDir = fullfile(applicationDir,"+Palladium","+Sequence","+Views");
+            fullViewCodeFilePath = fullfile(viewDir,viewFileName);
             namespaceClassPath = "Palladium.Sequence.Views." + viewFileName;
 
             %Check that this file exists in the expected folder

--- a/Palladium DAQ/Palladium.m
+++ b/Palladium DAQ/Palladium.m
@@ -208,8 +208,8 @@ classdef Palladium < handle
             %from the desired filename
 
             %Construct the needed paths
-            viewDir = applicationDir + "\\+Palladium\\+Views\\";
-            fullViewCodeFilePath = viewDir + viewFileName;
+            viewDir = fullfile(applicationDir,"+Palladium","+Views");
+            fullViewCodeFilePath = fullfile(viewDir,viewFileName);
             namespaceClassPath = "Palladium.Views." + viewFileName;
 
             %Check that this file exists in the expected folder


### PR DESCRIPTION
Removed instances of '\\' Windows-specific file path separators, replaced with fullfile calls. ConfigIO has 'filesep' characters, which look ok too.

Github actions CI tests should now be testing these calls on the Linux servers there going forward.