### PR TITLE
 #108 - issues in deployed .exe standalone code vs open source toolbox versions

### DIFF
--- a/Palladium DAQ/+Palladium/+Core/Controller.m
+++ b/Palladium DAQ/+Palladium/+Core/Controller.m
@@ -380,30 +380,32 @@ classdef Controller < handle
                 this.UserFilesDir = Palladium.Utilities.PathUtils.CleanPath(this.PathSettings.UserFilesDirectory);
                 this.EnsureUserFilesDirExists(this.UserFilesDir);
 
-                %Copy example/template Instrument class files into that
-                %folder if they don't yet exist
-                classesToCopy = "TemplateInstrumentClass.m";
-                Palladium.Utilities.PathUtils.CopyFiles(classesToCopy,...
-                    fullfile(this.ApplicationDir, "+Palladium", "+Instruments"), this.UserInstrumentsDir,...
-                    Overwrite=false);
- 
-                %Copy example/template Preset class files into that
-                %folder if they don't yet exist
-                classesToCopy = "Example.m";
-                Palladium.Utilities.PathUtils.CopyFiles(classesToCopy,...
-                    fullfile(this.ApplicationDir, "+PalladiumPresets"), this.UserPresetsDir,...
-                    Overwrite=false);
+                if ~isdeployed
+                    %Copy example/template Instrument class files into that
+                    %folder if they don't yet exist
+                    classesToCopy = "TemplateInstrumentClass.m";
+                    Palladium.Utilities.PathUtils.CopyFiles(classesToCopy,...
+                        fullfile(this.ApplicationDir, "+Palladium", "+Instruments"), this.UserInstrumentsDir,...
+                        Overwrite=false);
 
-                %Copy Instrument Drivers class files into User Instrument
-                %Drivers folder if they don't yet exist. At the moment this
-                %is just the QDInterface dll which almost certainly needs
-                %to sit in a folder alongside the QDInstrument dll file
-                %that the user will have to install themselves.
-                classesToCopy = "QDInterface.dll";
-                Palladium.Utilities.PathUtils.CopyFiles(classesToCopy,...
-                    fullfile(this.ApplicationDir, "Instrument Drivers", "Quantum Design", "PPMS Communication"),...
-                    fullfile(this.UserInstrumentDriversDir, "Quantum Design", "PPMS Communication"),...
-                    Overwrite=false);
+                    %Copy example/template Preset class files into that
+                    %folder if they don't yet exist
+                    classesToCopy = "Example.m";
+                    Palladium.Utilities.PathUtils.CopyFiles(classesToCopy,...
+                        fullfile(this.ApplicationDir, "+PalladiumPresets"), this.UserPresetsDir,...
+                        Overwrite=false);
+
+                    %Copy Instrument Drivers class files into User Instrument
+                    %Drivers folder if they don't yet exist. At the moment this
+                    %is just the QDInterface dll which almost certainly needs
+                    %to sit in a folder alongside the QDInstrument dll file
+                    %that the user will have to install themselves.
+                    classesToCopy = "QDInterface.dll";
+                    Palladium.Utilities.PathUtils.CopyFiles(classesToCopy,...
+                        fullfile(this.ApplicationDir, "Instrument Drivers", "Quantum Design", "PPMS Communication"),...
+                        fullfile(this.UserInstrumentDriversDir, "Quantum Design", "PPMS Communication"),...
+                        Overwrite=false);
+                end
 
                 %Retrieve iconPath to pass to a GUI
                 this.WindowSettings.PalladiumIconPath = fullfile(this.ApplicationDir, "+Palladium", "+Components", "Graphics", "PalladiumDAQIcon.png");
@@ -927,12 +929,17 @@ classdef Controller < handle
             %And set up a Quantum Design/PPMS Communication folder inside
             %there, which will get the provided QDInterface.dll copied into
             %it
-            Palladium.Utilities.PathUtils.EnsureDirectoryExists(fullfile(this.UserInstrumentDriversDir, "Quantum Design", "PPMS Communication"));
+            if ~isdeployed
+                %todo - do something in deployed code here
+                Palladium.Utilities.PathUtils.EnsureDirectoryExists(fullfile(this.UserInstrumentDriversDir, "Quantum Design", "PPMS Communication"));
+            end
 
 
             %Add the User Dir to the MATLAB path
-            addpath(userDirPath);
-            addpath(genpath(this.UserInstrumentDriversDir));    %Includes subfolders
+            if ~isdeployed
+                addpath(userDirPath);
+                addpath(genpath(this.UserInstrumentDriversDir));    %Includes subfolders
+            end
         end
 
         function [logSettings, pathSettings, windowSettings, plotterSettings] = LoadSettings(this, Settings)

--- a/Palladium DAQ/+Palladium/+Core/InstrumentController.m
+++ b/Palladium DAQ/+Palladium/+Core/InstrumentController.m
@@ -422,10 +422,17 @@ classdef InstrumentController < handle
             %Load the names of the classes from the built-in and User Files
             %Instruments directories
             builtInClassNames = Palladium.Utilities.PluginLoading.LoadPluginNames(builtInInstrsFolderPath);
-            userClassNames = Palladium.Utilities.PluginLoading.LoadPluginNames(userInstrsFolderPath);
 
-            %Combine the two lists
-            classNames = [builtInClassNames; userClassNames];
+            %Add on user classes if we are not deployed, ie are able to
+            %load in external .m files
+            if ~isdeployed
+                userClassNames = Palladium.Utilities.PluginLoading.LoadPluginNames(userInstrsFolderPath);
+
+                %Combine the two lists
+                classNames = [builtInClassNames; userClassNames];
+            else
+                classNames = builtInClassNames;
+            end
 
             %Remove any entries that are specified to be exluded - like
             %TemplateInstrumentClass


### PR DESCRIPTION
This is absolutely a work in progress, putting this up here for us all to be able to review and look at together, not because it should be approved any time soon!

This PR is to look at #108 - issues in deployed .exe standalone code vs open source toolbox versions.

Latest commit:
With some isdeployed checks added as a temporary fix, this now builds… and runs as a standalone exe.

Known immediate issues/concerns:
- No Instruments get loaded (!). Presumably because the search for them is based on paths, and those no longer exist inside the exe. Switch to namespace-based instead?
- Where does the Settings file go...?
- Copying of eg PPMS dll files to User dir had garbled paths and is just disabled for now. Need to.. supply a data archive folder alongside the exe with things like that in..?